### PR TITLE
Remove vanished build-depends target

### DIFF
--- a/content/latest/installing.md
+++ b/content/latest/installing.md
@@ -69,7 +69,6 @@ need to install the <strong>nodejs-legacy</strong> package for Node.js dependenc
 At the top the sources directory, run the build command:
 
 ```
-make build-depends
 make
 make install
 ```


### PR DESCRIPTION
The target was removed in [b67911656ef5d18c4ae36cb6741b7965](https://github.com/facette/facette/commit/b37eba5c7d03276dac8ef11a689e86568248edff#diff-b67911656ef5d18c4ae36cb6741b7965)